### PR TITLE
A macro for _ as a function argument placeholder in pipeline expressions

### DIFF
--- a/src/SAC.jl
+++ b/src/SAC.jl
@@ -3,10 +3,12 @@ module SAC
 export group, groupinds, Groups, groupview, groupreduce
 export innerjoin, leftgroupjoin
 export only
+export @_
 
 include("group.jl")
 include("innerjoin.jl")
 include("leftgroupjoin.jl")
 include("only.jl")
+include("underscore.jl")
 
 end # module

--- a/src/underscore.jl
+++ b/src/underscore.jl
@@ -1,3 +1,16 @@
+# Really dumb variable name replacement macro.  Doesn't know about scopes or
+# the gory details of any `Expr`s
+function replace_var!(ex, varname, replacement)
+    if ex isa Expr
+        map!(e->replace_var!(e, varname, replacement), ex.args, ex.args)
+        return ex
+    elseif ex === varname
+        return replacement
+    else
+        return ex
+    end
+end
+
 function expand_underscores_!(ex)
     if ex === :_
         return true
@@ -14,15 +27,28 @@ function expand_underscores_!(ex)
     end
 end
 
-
 function expand_underscores!(ex)
     if expand_underscores_!(ex)
-        return Expr(:->, :_, ex)
+        return replace_var!(Expr(:->, :_, ex), :_, gensym("_"))
     else
         ex
     end
 end
 
+"""
+    @_ ex
+
+Expand an expression containing underscore placeholders into a lambda.  The
+lambda head is placed at the outermost scope, except where interrupted by `|>`
+pipe operators.
+
+# Examples
+
+`data |> reduce(+,_)`  expands to  `data |> x->reduce(+,_)`
+
+`data |> foo(bar(_))`  expands to  `data |> x->foo(bar(x))
+
+"""
 macro _(ex)
     esc(expand_underscores!(ex))
 end

--- a/src/underscore.jl
+++ b/src/underscore.jl
@@ -1,0 +1,28 @@
+function expand_underscores_!(ex)
+    if ex === :_
+        return true
+    end
+    if ex isa Expr
+        if (ex.head == :call && ex.args[1] == :|>)
+            map!(expand_underscores!, ex.args, ex.args)
+            return false
+        else
+            return any(expand_underscores_!, ex.args)
+        end
+    else
+        return false
+    end
+end
+
+
+function expand_underscores!(ex)
+    if expand_underscores_!(ex)
+        return Expr(:->, :_, ex)
+    else
+        ex
+    end
+end
+
+macro _(ex)
+    esc(expand_underscores!(ex))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,5 @@ include("group.jl")
 include("innerjoin.jl")
 include("leftgroupjoin.jl")
 include("only.jl")
+include("underscore.jl")
+

--- a/test/underscore.jl
+++ b/test/underscore.jl
@@ -1,0 +1,13 @@
+
+@testset "underscore" begin
+    data = [1,2,3]
+    @test @_(data |> sum(_)) == 6
+    a = 10
+    @test @_(data |> _ .+ a) == data .+ a
+    @test @_(data |> _.^2 .+ _ |> sum) == sum(data.^2 .+ data)
+
+    two_outputs(x) = (x, x.+1)
+    @test @_(data |> two_outputs |> _[1] |> sum) == sum(data)
+    @test @_(data |> two_outputs |> _[2] |> sum) == sum(data.+1)
+end
+


### PR DESCRIPTION
This allows things like

```
@_ data |> reduce(+, _) |> iseven
```

to stand for

```
data |> x->reduce(+, x) |> iseven
```